### PR TITLE
bugfix: nameApiServiceのapiが死んでるので差し替えた

### DIFF
--- a/jestSample/nameApiService.ts
+++ b/jestSample/nameApiService.ts
@@ -6,9 +6,10 @@ export class NameApiService {
 
   public async getFirstName(): Promise<string> {
     const { data } = await axios.get(
-      "https://random-data-api.com/api/name/random_name"
+      "https://randomuser.me/api/"
     );
-    const firstName = data.first_name as string;
+
+    const firstName = data.results[0].name.first as string;
 
     if (firstName.length > this.MAX_LENGTH) {
       throw new Error("firstName is too long!");


### PR DESCRIPTION
# 概要

表題の通りです。

原因は不明ですが、
https://random-data-api.com/api/name/random_name
がしばらく前から死んでるみたいです。
(アクセスするとわかるのですが、名前解決すらできないみたいです。)

そのため、同様のAPIである
https://randomuser.me/api/
に差し替えました。

# 動作確認

``` bash
## 失敗時
$ npx ts-node -e "import { getFirstNameThrowIfLong } from './functions'; getFirstNameThrowIfLong(10).then(console.log).catch(console.error)"
Error: firstName is too long!
    at NameApiService.<anonymous> (/Users/masuyamayo/develop/praha/praha-challenge-templates/jestSample/nameApiService.ts:15:13)
    at step (/Users/masuyamayo/develop/praha/praha-challenge-templates/jestSample/nameApiService.ts:33:23)
    at Object.next (/Users/masuyamayo/develop/praha/praha-challenge-templates/jestSample/nameApiService.ts:14:53)
    at fulfilled (/Users/masuyamayo/develop/praha/praha-challenge-templates/jestSample/nameApiService.ts:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)

## 成功時
$ npx ts-node -e "import { getFirstNameThrowIfLong } from './functions'; getFirstNameThrowIfLong(10).then(console.log).catch(console.error)"
Greg
```
